### PR TITLE
Add a way to filter out span that we don't need

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -67,7 +67,7 @@ func WithSpanFilterOnlyScopeNames(names ...string) SpanProcessorWrapper {
 	}
 
 	return WithSpanFilter(func(span trace.ReadOnlySpan) bool {
-		_, ok := nameSet[span.InstrumentationLibrary().Name]
+		_, ok := nameSet[span.InstrumentationScope().Name]
 		return ok
 	})
 }

--- a/filter.go
+++ b/filter.go
@@ -59,3 +59,15 @@ func WithSpanFilterOnlyNames(names ...string) SpanProcessorWrapper {
 		return ok
 	})
 }
+
+func WithSpanFilterOnlyScopeNames(names ...string) SpanProcessorWrapper {
+	nameSet := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		nameSet[name] = struct{}{}
+	}
+
+	return WithSpanFilter(func(span trace.ReadOnlySpan) bool {
+		_, ok := nameSet[span.InstrumentationLibrary().Name]
+		return ok
+	})
+}

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,63 @@
+package otelutil
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+type filteringSpanProcessor struct {
+	namesMap map[string]struct{}
+	sp       trace.SpanProcessor
+}
+
+var _ trace.SpanProcessor = (*filteringSpanProcessor)(nil)
+
+func (f *filteringSpanProcessor) needsToBeFiltered(spanName string) bool {
+	if len(f.namesMap) == 0 {
+		return false
+	}
+	_, ok := f.namesMap[spanName]
+	return !ok
+}
+
+func (f *filteringSpanProcessor) OnStart(parent context.Context, s trace.ReadWriteSpan) {
+	spanName := s.Name()
+	if f.needsToBeFiltered(spanName) {
+		// No further processing if the span is not an application span
+		return
+	}
+
+	// Continue processing if it's an application span
+	f.sp.OnStart(parent, s)
+}
+
+func (f *filteringSpanProcessor) OnEnd(s trace.ReadOnlySpan) {
+	spanName := s.Name()
+	if f.needsToBeFiltered(spanName) {
+		// No further processing if the span is not an application span
+		return
+	}
+
+	// Continue processing if it's an application span
+	f.sp.OnEnd(s)
+}
+
+func (f *filteringSpanProcessor) Shutdown(ctx context.Context) error {
+	return f.sp.Shutdown(ctx)
+}
+
+func (f *filteringSpanProcessor) ForceFlush(ctx context.Context) error {
+	return f.sp.ForceFlush(ctx)
+}
+
+func WithSpanFilter(sp trace.SpanProcessor, onlyNames ...string) trace.SpanProcessor {
+	namesMap := make(map[string]struct{}, len(onlyNames))
+	for _, name := range onlyNames {
+		namesMap[name] = struct{}{}
+	}
+	return &filteringSpanProcessor{
+		sp:       sp,
+		namesMap: namesMap,
+	}
+}

--- a/filter.go
+++ b/filter.go
@@ -71,3 +71,12 @@ func WithSpanFilterOnlyScopeNames(names ...string) SpanProcessorWrapper {
 		return ok
 	})
 }
+
+func WithMultipleSpanFilters(wrappers ...SpanProcessorWrapper) SpanProcessorWrapper {
+	return func(sp trace.SpanProcessor) trace.SpanProcessor {
+		for _, wrapper := range wrappers {
+			sp = wrapper(sp)
+		}
+		return sp
+	}
+}

--- a/trace.go
+++ b/trace.go
@@ -54,12 +54,12 @@ func Get(name string) Tracer {
 	return otel.GetTracerProvider().Tracer(name)
 }
 
-// GetWithMemo returns a function that returns the Tracer object based on the name.
+// GetDeferedTracer returns a function that returns the Tracer object based on the name.
 // usually this function needs to be called only once at global scope of the package
 // and te reason it returns a function is that to defer getting tracer object until
 // it has been initliazed. Usually initialization of the tracer object is done in the
 // main function and it requires some time to initialize the object globally
-func GetWithMemo(name string) func() Tracer {
+func GetDeferedTracer(name string) func() Tracer {
 	var tracer Tracer
 	var once sync.Once
 

--- a/trace.go
+++ b/trace.go
@@ -24,6 +24,7 @@ import (
 // Tracer is an alias for oteltrace.Tracer.
 // to simplify the import path for the user.
 type Tracer = oteltrace.Tracer
+type ReadOnlySpan = trace.ReadOnlySpan
 
 // Use SpanFromContext to get the span from the context.
 var SpanFromContext = oteltrace.SpanFromContext

--- a/trace.go
+++ b/trace.go
@@ -175,7 +175,6 @@ func SetupGoogleTraceOTEL(ctx context.Context, optFns ...GoogleTraceOption) (shu
 				),
 			),
 		),
-		trace.WithBatcher(exporter),
 		trace.WithResource(res),
 	}
 
@@ -184,9 +183,14 @@ func SetupGoogleTraceOTEL(ctx context.Context, optFns ...GoogleTraceOption) (shu
 			providerOpts,
 			trace.WithSpanProcessor(
 				opt.spanProcessorWrapper(
-					trace.NewSimpleSpanProcessor(exporter),
+					trace.NewBatchSpanProcessor(exporter),
 				),
 			),
+		)
+	} else {
+		providerOpts = append(
+			providerOpts,
+			trace.WithBatcher(exporter),
 		)
 	}
 

--- a/trace.go
+++ b/trace.go
@@ -54,6 +54,11 @@ func Get(name string) Tracer {
 	return otel.GetTracerProvider().Tracer(name)
 }
 
+// GetWithMemo returns a function that returns the Tracer object based on the name.
+// usually this function needs to be called only once at global scope of the package
+// and te reason it returns a function is that to defer getting tracer object until
+// it has been initliazed. Usually initialization of the tracer object is done in the
+// main function and it requires some time to initialize the object globally
 func GetWithMemo(name string) func() Tracer {
 	var tracer Tracer
 	var once sync.Once
@@ -82,7 +87,6 @@ type googleTraceOpt struct {
 	name                 string
 	projectId            string
 	sampleRate           float64
-	onlySpanNames        []string
 	spanProcessorWrapper SpanProcessorWrapper
 }
 


### PR DESCRIPTION
Since some of the frameworks and internal libraries also add spans to otel, we want an ability to filter those out. This Pr add a new filter mechanism to filter out unwanted spans to be send to Google trace. 

For example, if we want to filter out everything except couple of names, we can use 

```golang
SetupGoogleTraceOTEL(
	context.Background(),
	WithSpanProcessor(
                // only process spans with name "span1", "span2"
		WithSpanFilterOnlyNames("span1", "span2"), 
	),
)
```