### PR TITLE
Change the signature of RecordError

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -66,11 +66,9 @@ func GetWithMemo(name string) func() Tracer {
 	}
 }
 
-func RecordError(span oteltrace.Span, err *error) func() {
-	return func() {
-		if err != nil && *err != nil {
-			span.RecordError(*err)
-		}
+func RecordError(span oteltrace.Span, err *error) {
+	if err != nil && *err != nil {
+		span.RecordError(*err)
 	}
 }
 


### PR DESCRIPTION
After a discussion, we decided to change the signature of RecordError to somthing simpler which can be used as follows

```golang
func A() (err error) {
    defer otelutil.RecordError(span, &err)
}
```

to record the error if error happens.