### PR TITLE
simplify the library by introduing span start attribute and the corre…

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -1,0 +1,22 @@
+package otelutil
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+var WithAttributes = oteltrace.WithAttributes
+
+var AttrString = attribute.String
+var AttrInt64 = attribute.Int64
+var AttrInt = attribute.Int
+
+var DefaultSpanStartAttributes = []attribute.KeyValue{}
+
+func SetWithDefaultSpanStartAttributes(attrs ...attribute.KeyValue) {
+	DefaultSpanStartAttributes = attrs
+}
+
+func GetWithDefaultSpanStartAttributes() oteltrace.SpanStartEventOption {
+	return WithAttributes(DefaultSpanStartAttributes...)
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/samber/lo v1.47.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/bridges/prometheus v0.53.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/handler.go
+++ b/handler.go
@@ -5,11 +5,10 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func WithSpanStartAttrs(attrs ...attribute.KeyValue) otelhttp.Option {
-	return otelhttp.WithSpanOptions(trace.WithAttributes(attrs...))
+	return otelhttp.WithSpanOptions(WithAttributes(attrs...))
 }
 
 func NewHandler(handler http.Handler, operation string, opts ...otelhttp.Option) http.Handler {

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,17 @@
+package otelutil
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func WithSpanStartAttrs(attrs ...attribute.KeyValue) otelhttp.Option {
+	return otelhttp.WithSpanOptions(trace.WithAttributes(attrs...))
+}
+
+func NewHandler(handler http.Handler, operation string, opts ...otelhttp.Option) http.Handler {
+	return otelhttp.NewMiddleware(operation, opts...)(handler)
+}

--- a/sampler.go
+++ b/sampler.go
@@ -7,12 +7,12 @@ import (
 )
 
 // sampler -  if the span has the specified attributes and the base sampler would have sampled it, then it will be sampled.
-type sampler struct {
+type attributeSampler struct {
 	base  sdktrace.Sampler
 	attrs map[attribute.Key]attribute.Value
 }
 
-func (cs sampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+func (cs attributeSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
 	result := cs.base.ShouldSample(p)
 	if result.Decision != sdktrace.RecordAndSample {
 		return result
@@ -39,16 +39,16 @@ func (cs sampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingR
 	return sdktrace.SamplingResult{Decision: sdktrace.Drop, Attributes: p.Attributes, Tracestate: psc.TraceState()}
 }
 
-func (cs sampler) Description() string {
-	return "sampler with base sampler: " + cs.base.Description()
+func (cs attributeSampler) Description() string {
+	return "attribute sampler with base sampler: " + cs.base.Description()
 }
 
-func NewSampler(base sdktrace.Sampler, attrs ...attribute.KeyValue) sdktrace.Sampler {
+func NewAttributeSampler(base sdktrace.Sampler, attrs ...attribute.KeyValue) sdktrace.Sampler {
 	m := map[attribute.Key]attribute.Value{}
 	for _, attr := range attrs {
 		m[attr.Key] = attr.Value
 	}
-	return sampler{
+	return attributeSampler{
 		base:  base,
 		attrs: m,
 	}

--- a/sampler.go
+++ b/sampler.go
@@ -6,15 +6,19 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// SamplerWithSpanStartAttrFilter -  if the span has the specified attributes and the base sampler would have sampled it, then it will be sampled.
-type SamplerWithSpanStartAttrFilter struct {
+// sampler -  if the span has the specified attributes and the base sampler would have sampled it, then it will be sampled.
+type sampler struct {
 	base  sdktrace.Sampler
 	attrs map[attribute.Key]attribute.Value
 }
 
-func (cs SamplerWithSpanStartAttrFilter) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+func (cs sampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
 	result := cs.base.ShouldSample(p)
 	if result.Decision != sdktrace.RecordAndSample {
+		return result
+	}
+
+	if len(cs.attrs) == 0 {
 		return result
 	}
 
@@ -22,7 +26,7 @@ func (cs SamplerWithSpanStartAttrFilter) ShouldSample(p sdktrace.SamplingParamet
 
 	for _, attr := range p.Attributes {
 		if val, ok := cs.attrs[attr.Key]; ok {
-			if val == attr.Value {
+			if val.AsString() == attr.Value.AsString() {
 				return sdktrace.SamplingResult{
 					Decision:   sdktrace.RecordAndSample,
 					Attributes: p.Attributes,
@@ -35,17 +39,16 @@ func (cs SamplerWithSpanStartAttrFilter) ShouldSample(p sdktrace.SamplingParamet
 	return sdktrace.SamplingResult{Decision: sdktrace.Drop, Attributes: p.Attributes, Tracestate: psc.TraceState()}
 }
 
-func (cs SamplerWithSpanStartAttrFilter) Description() string {
-	return "SamplerWithSpanStartAttrFilter with base sampler: " + cs.base.Description()
+func (cs sampler) Description() string {
+	return "sampler with base sampler: " + cs.base.Description()
 }
 
-func NewSamplerWithSpanStartAttrFilter(base sdktrace.Sampler, attrs ...attribute.KeyValue) sdktrace.Sampler {
+func NewSampler(base sdktrace.Sampler, attrs ...attribute.KeyValue) sdktrace.Sampler {
 	m := map[attribute.Key]attribute.Value{}
 	for _, attr := range attrs {
 		m[attr.Key] = attr.Value
 	}
-
-	return SamplerWithSpanStartAttrFilter{
+	return sampler{
 		base:  base,
 		attrs: m,
 	}

--- a/sampler.go
+++ b/sampler.go
@@ -3,32 +3,50 @@ package otelutil
 import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
-type AlwaysErrorSampler struct {
-	base sdktrace.Sampler
+// SamplerWithSpanStartAttrFilter -  if the span has the specified attributes and the base sampler would have sampled it, then it will be sampled.
+type SamplerWithSpanStartAttrFilter struct {
+	base  sdktrace.Sampler
+	attrs map[attribute.Key]attribute.Value
 }
 
-func (cs AlwaysErrorSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
-	// Check if the span has an error status
+func (cs SamplerWithSpanStartAttrFilter) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	result := cs.base.ShouldSample(p)
+	if result.Decision != sdktrace.RecordAndSample {
+		return result
+	}
+
+	psc := trace.SpanContextFromContext(p.ParentContext)
+
 	for _, attr := range p.Attributes {
-		if attr.Key == attribute.Key("status") && attr.Value.AsString() == "error" {
-			return sdktrace.SamplingResult{
-				Decision:   sdktrace.RecordAndSample,
-				Attributes: p.Attributes,
+		if val, ok := cs.attrs[attr.Key]; ok {
+			if val == attr.Value {
+				return sdktrace.SamplingResult{
+					Decision:   sdktrace.RecordAndSample,
+					Attributes: p.Attributes,
+					Tracestate: psc.TraceState(),
+				}
 			}
 		}
 	}
-	// Fallback to base/default sampling
-	return cs.base.ShouldSample(p)
+
+	return sdktrace.SamplingResult{Decision: sdktrace.Drop, Attributes: p.Attributes, Tracestate: psc.TraceState()}
 }
 
-func (cs AlwaysErrorSampler) Description() string {
-	return "AlwaysErrorSampler with TraceIDRatioBased and always sample errors"
+func (cs SamplerWithSpanStartAttrFilter) Description() string {
+	return "SamplerWithSpanStartAttrFilter with base sampler: " + cs.base.Description()
 }
 
-func NewAlwaysErrorSampler(base sdktrace.Sampler) sdktrace.Sampler {
-	return AlwaysErrorSampler{
-		base: base,
+func NewSamplerWithSpanStartAttrFilter(base sdktrace.Sampler, attrs ...attribute.KeyValue) sdktrace.Sampler {
+	m := map[attribute.Key]attribute.Value{}
+	for _, attr := range attrs {
+		m[attr.Key] = attr.Value
+	}
+
+	return SamplerWithSpanStartAttrFilter{
+		base:  base,
+		attrs: m,
 	}
 }

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/blockthrough/otelutil.go"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -24,6 +25,42 @@ func TestSamplerWithSpanStartFilter(t *testing.T) {
 
 	// Start a span with a name and attribute name matching the attribute we want to filter
 	ctx, span := tracer.Start(ctx, "test-span-1", trace.WithAttributes(keyVal))
+	span.End()
+
+	// Start a span with a name and attribute name NOT matching the attribute we want to filter
+	ctx, span = tracer.Start(ctx, "test-span-2", trace.WithAttributes(attribute.KeyValue{
+		Key:   "test-attr-2",
+		Value: attribute.StringValue("test-val-2"),
+	}))
+	span.End()
+
+	tp.ForceFlush(ctx)
+
+	// Fetch the spans from the TracerProvider
+	spans := getSpans()
+
+	assert.Len(t, spans, 1)
+
+	assert.Equal(t, "test-span-1", spans[0].Name)
+}
+
+func TestSamplerWithDefaultSpanStartFilter(t *testing.T) {
+	t.Parallel()
+
+	keyVal := attribute.KeyValue{
+		Key:   "test-attr",
+		Value: attribute.StringValue("test-val"),
+	}
+	tp, getSpans := createTestTraceProvider(t, nil, keyVal)
+
+	otelutil.SetWithDefaultSpanStartAttributes(keyVal)
+
+	tracer := tp.Tracer("test-tracer")
+
+	ctx := context.Background()
+
+	// Start a span with a name and default attribute name matching the attribute we want to filter
+	ctx, span := tracer.Start(ctx, "test-span-1", otelutil.GetWithDefaultSpanStartAttributes())
 	span.End()
 
 	// Start a span with a name and attribute name NOT matching the attribute we want to filter

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -6,17 +6,13 @@ import (
 
 	"github.com/blockthrough/otelutil.go"
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func TestSamplerWithSpanStartFilter(t *testing.T) {
 	t.Parallel()
 
-	keyVal := attribute.KeyValue{
-		Key:   "test-attr",
-		Value: attribute.StringValue("test-val"),
-	}
+	keyVal := otelutil.AttrString("test-attr", "test-val")
+
 	tp, getSpans := createTestTraceProvider(t, nil, keyVal)
 
 	tracer := tp.Tracer("test-tracer")
@@ -24,14 +20,11 @@ func TestSamplerWithSpanStartFilter(t *testing.T) {
 	ctx := context.Background()
 
 	// Start a span with a name and attribute name matching the attribute we want to filter
-	ctx, span := tracer.Start(ctx, "test-span-1", trace.WithAttributes(keyVal))
+	ctx, span := tracer.Start(ctx, "test-span-1", otelutil.WithAttributes(keyVal))
 	span.End()
 
 	// Start a span with a name and attribute name NOT matching the attribute we want to filter
-	ctx, span = tracer.Start(ctx, "test-span-2", trace.WithAttributes(attribute.KeyValue{
-		Key:   "test-attr-2",
-		Value: attribute.StringValue("test-val-2"),
-	}))
+	ctx, span = tracer.Start(ctx, "test-span-2", otelutil.WithAttributes(otelutil.AttrString("test-attr-2", "test-val-2")))
 	span.End()
 
 	tp.ForceFlush(ctx)
@@ -47,10 +40,8 @@ func TestSamplerWithSpanStartFilter(t *testing.T) {
 func TestSamplerWithDefaultSpanStartFilter(t *testing.T) {
 	t.Parallel()
 
-	keyVal := attribute.KeyValue{
-		Key:   "test-attr",
-		Value: attribute.StringValue("test-val"),
-	}
+	keyVal := otelutil.AttrString("test-attr", "test-val")
+
 	tp, getSpans := createTestTraceProvider(t, nil, keyVal)
 
 	otelutil.SetWithDefaultSpanStartAttributes(keyVal)
@@ -64,10 +55,7 @@ func TestSamplerWithDefaultSpanStartFilter(t *testing.T) {
 	span.End()
 
 	// Start a span with a name and attribute name NOT matching the attribute we want to filter
-	ctx, span = tracer.Start(ctx, "test-span-2", trace.WithAttributes(attribute.KeyValue{
-		Key:   "test-attr-2",
-		Value: attribute.StringValue("test-val-2"),
-	}))
+	ctx, span = tracer.Start(ctx, "test-span-2", otelutil.WithAttributes(otelutil.AttrString("test-attr-2", "test-val-2")))
 	span.End()
 
 	tp.ForceFlush(ctx)

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -1,0 +1,44 @@
+package otelutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSamplerWithSpanStartFilter(t *testing.T) {
+	t.Parallel()
+
+	keyVal := attribute.KeyValue{
+		Key:   "test-attr",
+		Value: attribute.StringValue("test-val"),
+	}
+	tp, getSpans := createTestTraceProvider(t, nil, keyVal)
+
+	tracer := tp.Tracer("test-tracer")
+
+	ctx := context.Background()
+
+	// Start a span with a name and attribute name matching the attribute we want to filter
+	ctx, span := tracer.Start(ctx, "test-span-1", trace.WithAttributes(keyVal))
+	span.End()
+
+	// Start a span with a name and attribute name NOT matching the attribute we want to filter
+	ctx, span = tracer.Start(ctx, "test-span-2", trace.WithAttributes(attribute.KeyValue{
+		Key:   "test-attr-2",
+		Value: attribute.StringValue("test-val-2"),
+	}))
+	span.End()
+
+	tp.ForceFlush(ctx)
+
+	// Fetch the spans from the TracerProvider
+	spans := getSpans()
+
+	assert.Len(t, spans, 1)
+
+	assert.Equal(t, "test-span-1", spans[0].Name)
+}

--- a/trace.go
+++ b/trace.go
@@ -133,8 +133,9 @@ func WithDefaultSpanStartAttributes(spanStartAttributes ...attribute.KeyValue) T
 
 func SetupTraceOTEL(ctx context.Context, optFns ...TraceOption) (*trace.TracerProvider, func(ctx context.Context) error, error) {
 	opt := traceOpt{
-		name:       "default-name",
-		sampleRate: 1.0,
+		name:             "default-name",
+		sampleRate:       1.0,
+		setDefaultTracer: true,
 	}
 
 	for _, fn := range optFns {

--- a/trace.go
+++ b/trace.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -74,6 +75,7 @@ func GetDeferedTracer(name string) func() Tracer {
 
 func RecordError(span oteltrace.Span, err *error) {
 	if err != nil && *err != nil {
+		span.SetStatus(codes.Error, "error recorded")
 		span.RecordError(*err)
 	}
 }

--- a/trace.go
+++ b/trace.go
@@ -90,10 +90,6 @@ func RecordError(span oteltrace.Span, err *error) {
 	}
 }
 
-func Start(ctx context.Context, tracer Tracer, name string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
-	return tracer.Start(ctx, name, opts...)
-}
-
 // Finish a span and record the error if any, this is a helper function
 // to simplify the code.
 func Finish(span oteltrace.Span, err *error) {

--- a/trace_test.go
+++ b/trace_test.go
@@ -18,7 +18,7 @@ func createTestTraceProvider(t *testing.T, filterFn otelutil.SpanProcessorWrappe
 		context.Background(),
 		otelutil.WithExporter(exp),
 		otelutil.WithSpanProcessor(filterFn),
-		otelutil.WithSpanStartAttributes(spanStartAttributes...),
+		otelutil.WithDefaultSpanStartAttributes(spanStartAttributes...),
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/trace_test.go
+++ b/trace_test.go
@@ -13,16 +13,18 @@ import (
 
 func createTestTraceProvider(t *testing.T, filterFn otelutil.SpanProcessorWrapper, spanStartAttributes ...attribute.KeyValue) (*otelutil.TracerProvider, func() tracetest.SpanStubs) {
 	// Create a TracerProvider using the Tracetest SDK
+	ctx := context.Background()
 	exp := tracetest.NewInMemoryExporter()
-	tp, err := otelutil.SetupTraceOTEL(
-		context.Background(),
+	tp, shutdown, err := otelutil.SetupTraceOTEL(
+		ctx,
 		otelutil.WithExporter(exp),
 		otelutil.WithSpanProcessor(filterFn),
 		otelutil.WithDefaultSpanStartAttributes(spanStartAttributes...),
+		otelutil.WithNotSetDefaultTracer(),
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
-		tp.Shutdown(context.Background())
+		shutdown(ctx)
 	})
 
 	return tp, exp.GetSpans

--- a/trace_test.go
+++ b/trace_test.go
@@ -5,18 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/blockthrough/otelutil.go"
 )
 
-func createTestTraceProvider(t *testing.T, filterFn otelutil.SpanProcessorWrapper) (*otelutil.TracerProvider, func() tracetest.SpanStubs) {
+func createTestTraceProvider(t *testing.T, filterFn otelutil.SpanProcessorWrapper, spanStartAttributes ...attribute.KeyValue) (*otelutil.TracerProvider, func() tracetest.SpanStubs) {
 	// Create a TracerProvider using the Tracetest SDK
 	exp := tracetest.NewInMemoryExporter()
 	tp, err := otelutil.SetupTraceOTEL(
 		context.Background(),
 		otelutil.WithExporter(exp),
 		otelutil.WithSpanProcessor(filterFn),
+		otelutil.WithSpanStartAttributes(spanStartAttributes...),
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/trace_test.go
+++ b/trace_test.go
@@ -13,15 +13,14 @@ import (
 func createTestTraceProvider(t *testing.T, filterFn otelutil.SpanProcessorWrapper) (*otelutil.TracerProvider, func() tracetest.SpanStubs) {
 	// Create a TracerProvider using the Tracetest SDK
 	exp := tracetest.NewInMemoryExporter()
-	tp, shutdown, err := otelutil.SetupTraceOTEL(
+	tp, err := otelutil.SetupTraceOTEL(
 		context.Background(),
 		otelutil.WithExporter(exp),
 		otelutil.WithSpanProcessor(filterFn),
-		otelutil.WithNotSetDefaultTracer(),
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
-		shutdown(context.Background())
+		tp.Shutdown(context.Background())
 	})
 
 	return tp, exp.GetSpans


### PR DESCRIPTION
*Change Set*
1. remove unnecessary wrappers that introduce a lot of mental overhead.
2. use the span start attribute to differentiate which span is explicitly created by blockthrough or a 3rd-party vendor library.
3.  remove always error sampler, as the error won't be available when the span is created