### PR TITLE
Expose error to span's attribute

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -72,6 +72,14 @@ func RecordError(span oteltrace.Span, err *error) {
 	if err != nil && *err != nil {
 		span.SetStatus(codes.Error, "error recorded")
 		span.RecordError(*err)
+
+		// since Grafana's Google Trace plugin doesn't support event and logs,
+		// we need to add the error message as an attribute to the span
+		// Will remove this once we migrate to Grafana's Tempo
+		span.SetAttributes(
+			attribute.Bool("has_error", true),
+			attribute.String("error_message", (*err).Error()),
+		)
 	}
 }
 

--- a/trace.go
+++ b/trace.go
@@ -77,7 +77,7 @@ func RecordError(span oteltrace.Span, err *error) {
 		// we need to add the error message as an attribute to the span
 		// Will remove this once we migrate to Grafana's Tempo
 		span.SetAttributes(
-			attribute.Int("error.code", 1),
+			attribute.Int64("error.code", int64(codes.Error)),
 			attribute.String("error.message", (*err).Error()),
 		)
 	}

--- a/trace.go
+++ b/trace.go
@@ -77,8 +77,8 @@ func RecordError(span oteltrace.Span, err *error) {
 		// we need to add the error message as an attribute to the span
 		// Will remove this once we migrate to Grafana's Tempo
 		span.SetAttributes(
-			attribute.Bool("has_error", true),
-			attribute.String("error_message", (*err).Error()),
+			attribute.Int("error.code", 1),
+			attribute.String("error.message", (*err).Error()),
 		)
 	}
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -90,11 +90,11 @@ func TestError(t *testing.T) {
 
 	s := spans[0]
 
-	hasError, ok := getAttribute(s.Attributes, "has_error")
+	hasError, ok := getAttribute(s.Attributes, "error.code")
 	assert.True(t, ok)
-	assert.Equal(t, true, hasError.AsBool())
+	assert.Equal(t, int64(1), hasError.AsInt64())
 
-	errMsg, ok := getAttribute(s.Attributes, "error_message")
+	errMsg, ok := getAttribute(s.Attributes, "error.message")
 	assert.True(t, ok)
 	assert.Equal(t, "test-error", errMsg.AsString())
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -2,6 +2,7 @@ package otelutil_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +56,45 @@ func TestSpanFilter(t *testing.T) {
 
 	assert.Equal(t, "test-span-1", spans[0].Name)
 	assert.Equal(t, "test-span-2", spans[1].Name)
+}
+
+func getAttribute(attributes []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attributes {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+
+	return attribute.Value{}, false
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	tp, getSpans := createTestTraceProvider(t, nil)
+
+	tracer := tp.Tracer("test-tracer")
+
+	ctx := context.Background()
+
+	ctx, span := tracer.Start(ctx, "test-span-1")
+	err := fmt.Errorf("test-error")
+
+	otelutil.Finish(span, &err)
+
+	tp.ForceFlush(ctx)
+
+	spans := getSpans()
+
+	assert.Len(t, spans, 1)
+
+	s := spans[0]
+
+	hasError, ok := getAttribute(s.Attributes, "has_error")
+	assert.True(t, ok)
+	assert.Equal(t, true, hasError.AsBool())
+
+	errMsg, ok := getAttribute(s.Attributes, "error_message")
+	assert.True(t, ok)
+	assert.Equal(t, "test-error", errMsg.AsString())
 }


### PR DESCRIPTION
Because Grafana's Google Trace plugin doesn't support Event and Log for errored spans, we need to add it to span's attributes so it can be queried using the limited Google Trace's query language.